### PR TITLE
Remove "slideshows" demo from config.yml.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,11 +16,6 @@ demos:
     tags: [svg]
     support: [svg]
 
-  - slug: slideshows 
-    title: "Slides from Web Openers"
-    tags: [css]
-    support: [pagedcontent]
-
   - slug: border-salon
     title: "Border Radius Salon"
     tags: [css]


### PR DESCRIPTION
This one won't make the initial launch. Some more context:

On Thu, 17 May 2012 10:37:34 +0200, Vadim Makeev pepelsbey@opera.com wrote:

http://people.opera.com/howcome/2012/reader/aiw/index.html showcases
multicol, and is clearly recognizable as a book. Maybe this is a better
fit?

We should probably clean up this demo (and the others in this way)

```
— alas, doesnt' seem to work
— hack to ensure page break, page breaks seems buggy in android builds
```

Thinking out loud - this would even be nice with some skeuomorphic
pages+wood or so around the edges, so as to make the "book" effect
stronger - not sure if we have time for that though.

I would love to make something beautiful (with cover, old paper and nice typography) when GCPM would become more visible in the next Opera releases — and when we would have more time 

It's being dropped from the press release as well. Should we drop this demo from Shinydemos as well? I'm inclined to...
