### PR TITLE
Remove Charade fallback videos from photobooth.

### DIFF
--- a/demos/photo-booth/index.html
+++ b/demos/photo-booth/index.html
@@ -8,10 +8,7 @@
 <body>
   <div id="container">
     <h1>Online Free PhotoBooth</h1>
-    <video width="640" height="400" preload muted>
-      <source src="charade.webm" type='video/webm; codecs="vp8, vorbis"'>
-      <source src="charade.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"'>
-    </video>
+    <video width="640" height="400">No fallback video here because, well that's not very interesting.</video>
     <canvas id="pics" width="680" height="187"></canvas>
     <button id="take-photo">Press Button To Take Photos</button>
     <img id="sticker" src="images/sticker_smiley.png" alt="">


### PR DESCRIPTION
Its Public Domain status seems to not apply in Norway. Also,
a photobooth strip of an old film isn't that interesting, so I'm
just leaving the fallback out.

If I wasn't lazy I'd pull out the 2 or 3 lines of code from `photobooth.js` as well--but I'll just leave it for now.
