### PR TITLE
add in GA. Closes #116.

### DIFF
--- a/source/scripts/panel.js
+++ b/source/scripts/panel.js
@@ -86,3 +86,13 @@ function appendPanel(options) {
 	body.appendChild(panel);
 
 }
+
+var _gaq = _gaq || [];
+_gaq.push(['_setAccount', 'UA-17110734-4']);
+_gaq.push(['_trackPageview']);
+
+(function() {
+	var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+	ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+	var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+})();


### PR DESCRIPTION
Adding in GA inside of panel.js. It's static, in the `<head>`, and we won't have to touch any markup.
