### PR TITLE
Moved demo titles slightly closer to their thumbnails

### DIFF
--- a/source/styles/screen.css
+++ b/source/styles/screen.css
@@ -143,7 +143,7 @@ a {
 		}
 		.demos li img {
 			display:block;
-			margin:0 0 30px;
+			margin:0 0 15px;
 			width:100%;
 			border-bottom:6px solid #333;
 			background:#000;


### PR DESCRIPTION
Reason: At first glance, users could be confused as to which thumbnail a title belongs to.
