### PR TITLE
Add a /all.html page. Closes #205.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -69,7 +69,9 @@ exports.renderDemos = function() {
   var optionsjs = Handlebars.compile(fs.readFileSync(siteconfig.layoutsFolder + '/options.{').toString()),
       demosByTag = {}, 
       tagNames, optsjs;
-      
+  
+  //manually create a special "all" object for /all.html
+  demosByTag.all = configs.demos;
   console.log('Creating demos from source files');
   
   //demo that gets passed in is configs.demo


### PR DESCRIPTION
Not linked from the UI anywhere, but way easier to quickly test things. It ends up with an empty `<p class=tagline>`, but I don't think that's important for a "hidden" feature.
